### PR TITLE
Configure JDK version for Heroku/Koyeb

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=17


### PR DESCRIPTION
## Summary
- specify JDK version for Heroku/JVM buildpack

## Testing
- `./gradlew test` *(fails: unable to download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686d45cb776c8323b1d3477ba5ce500d