### PR TITLE
Implement paginated posts endpoint

### DIFF
--- a/src/main/java/com/generation/EasterEgg/controllers/PublicacionesController.java
+++ b/src/main/java/com/generation/EasterEgg/controllers/PublicacionesController.java
@@ -29,6 +29,12 @@ public class PublicacionesController {
         return publicacionesService.getPostsFromOneUser(id);
     }
 
+    @GetMapping("/posts/all")
+    public List<Publicaciones> getAllPosts(@RequestParam(defaultValue = "0") int page,
+                                           @RequestParam(defaultValue = "5") int size) {
+        return publicacionesService.getAllPosts(page, size);
+    }
+
     @PostMapping("/post")
     public Publicaciones putPost(@RequestBody Publicaciones post){
         return publicacionesService.save(post);

--- a/src/main/java/com/generation/EasterEgg/service/PublicacionesService.java
+++ b/src/main/java/com/generation/EasterEgg/service/PublicacionesService.java
@@ -15,4 +15,6 @@ public interface PublicacionesService {
     void delete( Integer id );
 
     Publicaciones updatePost(Publicaciones post, Integer id);
+
+    List<Publicaciones> getAllPosts(int page, int size);
 }

--- a/src/main/java/com/generation/EasterEgg/service/PublicacionesServiceImpl.java
+++ b/src/main/java/com/generation/EasterEgg/service/PublicacionesServiceImpl.java
@@ -2,6 +2,9 @@ package com.generation.EasterEgg.service;
 
 import com.generation.EasterEgg.models.Publicaciones;
 import com.generation.EasterEgg.repository.PublicacionesRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
@@ -56,6 +59,12 @@ public class PublicacionesServiceImpl implements PublicacionesService{
             return publicacionesRepository.save(oldPost);
         }).orElse(null);
     };
+
+    @Override
+    public List<Publicaciones> getAllPosts(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("idPublicaciones").descending());
+        return publicacionesRepository.findAll(pageable).getContent();
+    }
 
 
 }


### PR DESCRIPTION
## Summary
- extend `PublicacionesService` with pagination method
- implement pagination in `PublicacionesServiceImpl`
- expose new `GET /posts/all` endpoint in `PublicacionesController`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686d6b2a060883239a883cb3c0196da1