### PR TITLE
Permit root and error paths without authentication

### DIFF
--- a/src/main/java/com/generation/EasterEgg/security/WebSecurity.java
+++ b/src/main/java/com/generation/EasterEgg/security/WebSecurity.java
@@ -53,6 +53,10 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST, LOGIN_URL).permitAll()
                 .antMatchers(HttpMethod.POST, "/post").permitAll()
                 .antMatchers(HttpMethod.POST, "/user").permitAll()
+                // Allow GET requests to the root URL without authentication
+                .antMatchers(HttpMethod.GET, "/").permitAll()
+                // Permit error page to avoid Whitelabel error page when unauthenticated
+                .antMatchers(HttpMethod.GET, "/error").permitAll()
                 .anyRequest().authenticated().and()
                 .addFilter(new JWTAuthenticationFilter(authenticationManager()))
                 .addFilter(new JWTAuthorizationFilter(authenticationManager()));


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `/` and `/error` in the security config

## Testing
- `./gradlew test` *(fails: unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686d72d4058c8323bc38602edd2f1768